### PR TITLE
Fixed 'The input length is not integer'

### DIFF
--- a/maplesyrup.js
+++ b/maplesyrup.js
@@ -47,7 +47,7 @@ var MapleSyrup;
                 if (index > 0 && change[0] > timeIndexMap[index - 1]) {
                     const timeGap = timeIndexMap[index] - change[0];
                     const noteToken = channelsAsTokens[i][index];
-                    let length = Number.isNaN(noteToken.value) ? getDefaultLengthByIndex(channelsAsTokens[i], index) : (128 / noteToken.value);
+                    let length = noteToken.value === undefined || Number.isNaN(noteToken.value) ? getDefaultLengthByIndex(channelsAsTokens[i], index) : (128 / noteToken.value);
                     if (noteToken.dot) {
                         length *= 1.5;
                     }
@@ -113,7 +113,7 @@ var MapleSyrup;
         if (index >= tokens.length) {
             throw new Error("Index cannot be greater than or equal to token length.");
         }
-        let defaultLength;
+        let defaultLength = 0;
         for (let i = 0; i < index; i++) {
             if (tokens[i].type === "defaultlength") {
                 defaultLength = 128 / tokens[i].value;


### PR DESCRIPTION
Example: https://musescore.com/user/27378550/scores/5111366 (converted to Mabinogi MML with 3MLE)
that causes
![image](https://user-images.githubusercontent.com/15276837/41305109-88756df0-6e37-11e8-8610-1522a7516792.png)

---

Pretty self-explanatory from commit but it is caused by:
* `Number.isNaN(undefined)` = false
* `getDefaultLengthByIndex` return undefined because none of the tokens' type are "defaultlength"